### PR TITLE
Allow BrowserConsoleHandler to output exceptions.

### DIFF
--- a/src/Monolog/Handler/BrowserConsoleHandler.php
+++ b/src/Monolog/Handler/BrowserConsoleHandler.php
@@ -195,6 +195,12 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
     private static function dump($title, array $dict)
     {
         $script = [];
+        
+        // Convert exception to string
+        if (isset($dict['exception'])) {
+            $dict['exception'] = (string)$dict['exception'];
+        }
+
         $dict = array_filter($dict);
         if (empty($dict)) {
             return $script;


### PR DESCRIPTION
Exceptions have all of their data as private/protected properties. When BrowserConsoleHandler attempts to output them they are inaccessible from the browser. This patch outputs them as a string instead.